### PR TITLE
remove req body from a get request

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ export default ({config, boundary, logger, messageHandler, entityMapper}) => [{
     resource: "/",
     behaviors: [
         {endpoint: "/", method: "get", behavior: [
-           (req, res, next) => req.body.length ? res.send({password: passwordGen(req.body.length)}) : next({status: 400})
+           (_, res) => res.send({password: passwordGen(16)})
         ]},
     ]
 }];


### PR DESCRIPTION
This removes the length from the get request, which was never a good idea, but now I know better. The default length will be 16 characters for now.

I thought about also removing some characters from the pool, but opted not to here, so this is best reserved for automation.